### PR TITLE
It looks like I've made some good progress on your request!

### DIFF
--- a/Recipeswipers/README.md
+++ b/Recipeswipers/README.md
@@ -1,0 +1,51 @@
+# Recipeswipers Project
+
+This project consists of a frontend application and a backend API for suggesting recipes.
+
+## Project Structure
+
+- `/frontend`: Contains the HTML, CSS, and JavaScript for the user interface.
+- `/backend`: Contains the Node.js Express server and API logic, including integration with the Gemini AI for recipe generation.
+- `openwebsite.py`: A utility script to quickly open the default frontend and backend URLs in your web browser.
+
+## Running the Application
+
+### 1. Backend Server
+
+- Navigate to the `Recipeswipers/backend` directory.
+- **Important:** Ensure you have a `.env` file in this directory with your `GEMINI_API_KEY`. Example:
+  ```
+  GEMINI_API_KEY=your_actual_api_key_here
+  PORT=3000
+  ```
+- Install dependencies: `npm install`
+- Start the server: `npm start` (or `npm run dev` for development with nodemon)
+- The backend will typically run on `http://localhost:3000`.
+
+### 2. Frontend Application
+
+- The frontend consists of static files in `Recipeswipers/frontend`.
+- You'll need to serve these files using a local web server. A common way is to use the "Live Server" extension in VS Code (which often defaults to `http://127.0.0.1:5500`).
+- Open `Recipeswipers/frontend/index.html` with your live server.
+
+### 3. Using `openwebsite.py`
+
+To quickly open the typical URLs for both the frontend live server and the backend server:
+
+- Make sure you are in the main `Recipeswipers` directory in your terminal.
+- Run the script using Python:
+  ```bash
+  python openwebsite.py
+  ```
+- This will attempt to open:
+    - `http://127.0.0.1:5500` (for the frontend)
+    - `http://localhost:3000` (for the backend)
+- If your ports are different, you can modify the `FRONTEND_URL` and `BACKEND_URL` variables directly within the `openwebsite.py` script.
+
+## Error: "Kon geen recept laden"
+
+If you encounter the "Kon geen recept laden" (Could not load recipe) error in the frontend:
+
+1.  **Check your `GEMINI_API_KEY`**: Ensure the `GEMINI_API_KEY` in `Recipeswipers/backend/.env` is correct and active. The backend server console will show an error if the key is missing or invalid.
+2.  **Check Backend Server Logs**: Look at the console output from your backend server. It might show errors related to the AI API call (e.g., "Fout bij AI receptgeneratie") or provide a "Raw AI Response" that was not valid JSON.
+3.  **Check Browser Developer Console (F12)**: In the Network tab, inspect the failed `/api/recipe` request. The response might give more details.

--- a/Recipeswipers/backend/server.js
+++ b/Recipeswipers/backend/server.js
@@ -96,6 +96,14 @@ Do not include fields such as imageUrl, bereidingstijd_minuten, moeilijkheidsgra
     }
     prompt += "\n\nBelangrijk: Geef ALLEEN het JSON object terug, zonder extra tekst ervoor of erna. Zorg dat de JSON geldig is."
 
+    if (!process.env.GEMINI_API_KEY) {
+        console.error("GEMINI_API_KEY is not configured.");
+        return res.status(503).json({
+            error: "Server configuration error",
+            message: "GEMINI_API_KEY is not configured. Please check server environment variables."
+        });
+    }
+
     try {
         console.log("AI Prompt:", prompt);
         const result = await model.generateContent(prompt);

--- a/Recipeswipers/openwebsite.py
+++ b/Recipeswipers/openwebsite.py
@@ -1,0 +1,29 @@
+import webbrowser
+import time
+
+# URLs to open
+# Common frontend live server URL (e.g., VS Code Live Server default)
+FRONTEND_URL = "http://127.0.0.1:5500"
+# Backend server URL (as defined in this project)
+BACKEND_URL = "http://localhost:3000"
+
+def open_urls():
+    """
+    Opens the predefined frontend and backend URLs in new browser tabs.
+    """
+    print(f"Attempting to open frontend: {FRONTEND_URL}")
+    webbrowser.open_new_tab(FRONTEND_URL)
+
+    # Add a small delay to allow the first tab to initiate opening
+    time.sleep(1)
+
+    print(f"Attempting to open backend: {BACKEND_URL}")
+    webbrowser.open_new_tab(BACKEND_URL)
+
+    print("\nScript finished.")
+    print("If the sites didn't open, ensure your frontend live server (e.g., VS Code Live Server)")
+    print("is running and configured for the frontend URL, and your backend server is running for the backend URL.")
+    print("You can modify the FRONTEND_URL and BACKEND_URL variables in this script if your ports differ.")
+
+if __name__ == "__main__":
+    open_urls()


### PR DESCRIPTION
Here's a summary of the changes:

**Fix: Add API key check to prevent recipe load error**

I've updated the backend code so that it now checks for the `GEMINI_API_KEY`. If this key is missing or not set up correctly in your `.env` file, the server will now let you know with a 503 error and a message explaining how to fix it. This should resolve the "Kon geen recept laden" error when it's due to a missing API key.

**Feat: Add openwebsite.py utility script**

I've also added a new Python script called `openwebsite.py` to the main project folder. This script will automatically open the default web addresses for your frontend (http://127.0.0.1:5500) and backend (http://localhost:3000) in your web browser.

**Docs: Add README.md with setup and usage instructions**

Finally, I've created a new `README.md` file in the main project folder. This file includes:
- An overview of how the project is organized.
- Instructions for setting up and running the backend and frontend.
- Information on how to use the new `openwebsite.py` script.
- Troubleshooting tips for the "Kon geen recept laden" error, with a focus on checking the API key.